### PR TITLE
Register Packet Handlers on Server/Register SoundEvents on Server

### DIFF
--- a/src/main/java/dev/sterner/GuardVillagersClient.java
+++ b/src/main/java/dev/sterner/GuardVillagersClient.java
@@ -27,25 +27,13 @@ public class GuardVillagersClient implements ClientModInitializer {
     public static EntityModelLayer GUARD_ARMOR_OUTER = new EntityModelLayer(new Identifier(GuardVillagers.MODID + "guard_armor_outer"), "guard_armor_outer");
     public static EntityModelLayer GUARD_ARMOR_INNER = new EntityModelLayer(new Identifier(GuardVillagers.MODID + "guard_armor_inner"), "guard_armor_inner");
 
-    public static SoundEvent GUARD_AMBIENT = SoundEvent.of(new Identifier(MODID, "entity.guard.ambient"));
-    public static SoundEvent GUARD_HURT = SoundEvent.of(new Identifier(MODID, "entity.guard.hurt"));
-    public static SoundEvent GUARD_DEATH = SoundEvent.of(new Identifier(MODID, "entity.guard.death"));
-
-
     @Override
     public void onInitializeClient() {
-        Registry.register(Registries.SOUND_EVENT, new Identifier(MODID, "entity.guard.ambient"), GUARD_AMBIENT);
-        Registry.register(Registries.SOUND_EVENT, new Identifier(MODID, "entity.guard.hurt"), GUARD_HURT);
-        Registry.register(Registries.SOUND_EVENT, new Identifier(MODID, "entity.guard.death"), GUARD_DEATH);
-
         HandledScreens.register(GUARD_SCREEN_HANDLER, GuardVillagerScreen::new);
         EntityModelLayerRegistry.registerModelLayer(GUARD, GuardVillagerModel::createBodyLayer);
         EntityModelLayerRegistry.registerModelLayer(GUARD_STEVE, GuardSteveModel::createMesh);
         EntityModelLayerRegistry.registerModelLayer(GUARD_ARMOR_OUTER, GuardArmorModel::createOuterArmorLayer);
         EntityModelLayerRegistry.registerModelLayer(GUARD_ARMOR_INNER, GuardArmorModel::createInnerArmorLayer);
         EntityRendererRegistry.register(GUARD_VILLAGER, GuardRenderer::new);
-
-        ServerPlayNetworking.registerGlobalReceiver(GuardFollowPacket.PACKET_TYPE, GuardFollowPacket::handle);
-        ServerPlayNetworking.registerGlobalReceiver(GuardPatrolPacket.PACKET_TYPE, GuardPatrolPacket::handle);
     }
 }

--- a/src/main/java/dev/sterner/common/entity/GuardEntity.java
+++ b/src/main/java/dev/sterner/common/entity/GuardEntity.java
@@ -3,7 +3,7 @@ package dev.sterner.common.entity;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.mojang.serialization.Dynamic;
-import dev.sterner.GuardVillagersClient;
+import dev.sterner.GuardVillagers;
 import dev.sterner.GuardVillagersConfig;
 import dev.sterner.common.entity.goal.*;
 import dev.sterner.common.screenhandler.GuardVillagerScreenHandler;
@@ -178,7 +178,7 @@ public class GuardEntity extends PathAwareEntity implements CrossbowUser, Ranged
 
     @Override
     protected SoundEvent getAmbientSound() {
-        return GuardVillagersClient.GUARD_AMBIENT;
+        return GuardVillagers.GUARD_AMBIENT;
     }
 
     @Override
@@ -186,13 +186,13 @@ public class GuardEntity extends PathAwareEntity implements CrossbowUser, Ranged
         if (this.isBlocking()) {
             return SoundEvents.ITEM_SHIELD_BLOCK;
         } else {
-            return GuardVillagersClient.GUARD_HURT;
+            return GuardVillagers.GUARD_HURT;
         }
     }
 
     @Override
     protected SoundEvent getDeathSound() {
-        return GuardVillagersClient.GUARD_DEATH;
+        return GuardVillagers.GUARD_DEATH;
     }
 
     @Override


### PR DESCRIPTION
Packet Handlers for the GuardFollowPacket and the GuardPatrolPacket were registered on the client. Which meant Follow and Patrol could not be used on a dedicated server (buttons do nothing).

The SoundEvents were registered on the client, which meant a dedicated server would crash because the GuardVillagersClient class is not available on the server.