### PR TITLE
Remove dependency on PortingLib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,6 @@ repositories {
 	maven {
 		url = "https://api.modrinth.com/maven"
 	}
-	maven { url = "https://mvn.devos.one/releases/" }
-	maven { url = "https://mvn.devos.one/snapshots/" }
 	maven {
 		url = "https://jitpack.io"
 	}
@@ -35,12 +33,6 @@ dependencies {
 
 	//MidnightLib
 	modImplementation include ("maven.modrinth:midnightlib:${project.midnightlib_version}")
-
-	modApi include("io.github.fabricators_of_create.Porting-Lib:common:${project.port_lib_version}+1.20")
-	modApi include("io.github.fabricators_of_create.Porting-Lib:extensions:${project.port_lib_version}+1.20")
-	modApi include("io.github.fabricators_of_create.Porting-Lib:base:${project.port_lib_version}+1.20")
-	modApi include("io.github.fabricators_of_create.Porting-Lib:tool_actions:${project.port_lib_version}+1.20")
-	modApi include("io.github.fabricators_of_create.Porting-Lib:entity:${project.port_lib_version}+1.20")
 
 	//modImplementation include("com.electronwill.night-config:core:${project.night_config_version}")
 

--- a/src/main/java/dev/sterner/guardvillagers/GuardVillagers.java
+++ b/src/main/java/dev/sterner/guardvillagers/GuardVillagers.java
@@ -1,14 +1,10 @@
 package dev.sterner.guardvillagers;
 
 import dev.sterner.guardvillagers.common.entity.GuardEntity;
-import dev.sterner.guardvillagers.common.entity.goal.AttackEntityDaytimeGoal;
-import dev.sterner.guardvillagers.common.entity.goal.HealGolemGoal;
-import dev.sterner.guardvillagers.common.entity.goal.HealGuardAndPlayerGoal;
 import dev.sterner.guardvillagers.common.network.GuardFollowPacket;
 import dev.sterner.guardvillagers.common.network.GuardPatrolPacket;
 import dev.sterner.guardvillagers.common.screenhandler.GuardVillagerScreenHandler;
 import eu.midnightdust.lib.config.MidnightConfig;
-import io.github.fabricators_of_create.porting_lib.entity.events.living.LivingEntityEvents;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 import net.fabricmc.fabric.api.event.player.UseEntityCallback;
@@ -17,19 +13,13 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
-import net.fabricmc.fabric.api.util.TriState;
 import net.minecraft.entity.*;
 import net.minecraft.entity.ai.brain.MemoryModuleType;
-import net.minecraft.entity.ai.goal.ActiveTargetGoal;
-import net.minecraft.entity.ai.goal.FleeEntityGoal;
-import net.minecraft.entity.ai.goal.PrioritizedGoal;
-import net.minecraft.entity.ai.goal.RevengeGoal;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.mob.*;
 import net.minecraft.entity.passive.*;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.entity.raid.RaiderEntity;
 import net.minecraft.item.*;
 import net.minecraft.particle.ParticleEffect;
 import net.minecraft.particle.ParticleTypes;
@@ -44,8 +34,6 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.village.VillagerProfession;
 import net.minecraft.world.World;
-import net.minecraft.world.WorldAccess;
-import net.minecraft.world.spawner.Spawner;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -85,7 +73,6 @@ public class GuardVillagers implements ModInitializer {
 
         ItemGroupEvents.modifyEntriesEvent(ItemGroups.FUNCTIONAL).register(entries -> entries.add(GUARD_SPAWN_EGG));
 
-        LivingEntityEvents.SET_TARGET.register(this::target);
         ServerLivingEntityEvents.ALLOW_DAMAGE.register(this::onDamage);
         UseEntityCallback.EVENT.register(this::villagerConvert);
     }
@@ -110,25 +97,6 @@ public class GuardVillagers implements ModInitializer {
             }
         }
         return shouldDamage;
-    }
-
-    private void target(MobEntity mob, @Nullable LivingEntity target) {
-        if (target == null || mob instanceof GuardEntity) {
-            return;
-        }
-        boolean isVillager = target.getType() == EntityType.VILLAGER || target instanceof GuardEntity;
-        if (isVillager) {
-            List<MobEntity> list = mob.getWorld().getNonSpectatingEntities(MobEntity.class, mob.getBoundingBox().expand(GuardVillagersConfig.guardVillagerHelpRange, 5.0D, GuardVillagersConfig.guardVillagerHelpRange));
-            for (MobEntity mobEntity : list) {
-                if ((mobEntity instanceof GuardEntity || mob.getType() == EntityType.IRON_GOLEM) && mobEntity.getTarget() == null) {
-                    mobEntity.setTarget(mob);
-                }
-            }
-        }
-
-        if (mob instanceof IronGolemEntity golem && target instanceof GuardEntity) {
-            golem.setTarget(null);
-        }
     }
 
     private ActionResult villagerConvert(PlayerEntity player, World world, Hand hand, Entity entity, @Nullable EntityHitResult entityHitResult) {

--- a/src/main/java/dev/sterner/guardvillagers/GuardVillagers.java
+++ b/src/main/java/dev/sterner/guardvillagers/GuardVillagers.java
@@ -85,7 +85,6 @@ public class GuardVillagers implements ModInitializer {
 
         ItemGroupEvents.modifyEntriesEvent(ItemGroups.FUNCTIONAL).register(entries -> entries.add(GUARD_SPAWN_EGG));
 
-        LivingEntityEvents.NATURAL_SPAWN.register(this::addGoals);
         LivingEntityEvents.SET_TARGET.register(this::target);
         ServerLivingEntityEvents.ALLOW_DAMAGE.register(this::onDamage);
         UseEntityCallback.EVENT.register(this::villagerConvert);
@@ -195,79 +194,6 @@ public class GuardVillagers implements ModInitializer {
         villagerEntity.releaseTicketFor(MemoryModuleType.JOB_SITE);
         villagerEntity.releaseTicketFor(MemoryModuleType.MEETING_POINT);
         villagerEntity.discard();
-    }
-
-    private TriState addGoals(MobEntity entity, double x, double y, double z, WorldAccess worldAccess, @Nullable Spawner spawner, SpawnReason spawnReason) {
-        if (GuardVillagersConfig.raidAnimals) {
-            if (entity instanceof RaiderEntity raiderEntity)
-                if (raiderEntity.hasActiveRaid()) {
-                    raiderEntity.targetSelector.add(5, new ActiveTargetGoal<>(raiderEntity, AnimalEntity.class, false));
-                }
-        }
-
-        if (GuardVillagersConfig.attackAllMobs) {
-            if (entity instanceof HostileEntity && !(entity instanceof SpiderEntity)) {
-                MobEntity mob = entity;
-                mob.targetSelector.add(2, new ActiveTargetGoal<>(mob, GuardEntity.class, false));
-            }
-            if (entity instanceof SpiderEntity spider) {
-                spider.targetSelector.add(3, new AttackEntityDaytimeGoal<>(spider, GuardEntity.class));
-            }
-        }
-
-
-        if (entity instanceof IllagerEntity illager) {
-            if (GuardVillagersConfig.illagersRunFromPolarBears) {
-                illager.goalSelector.add(2, new FleeEntityGoal<>(illager, PolarBearEntity.class, 6.0F, 1.0D, 1.2D));
-            }
-
-            illager.targetSelector.add(2, new ActiveTargetGoal<>(illager, GuardEntity.class, false));
-        }
-
-        if (entity instanceof VillagerEntity villagerEntity) {
-            if (GuardVillagersConfig.villagersRunFromPolarBears)
-                villagerEntity.goalSelector.add(2, new FleeEntityGoal<>(villagerEntity, PolarBearEntity.class, 6.0F, 1.0D, 1.2D));
-            if (GuardVillagersConfig.witchesVillager)
-                villagerEntity.goalSelector.add(2, new FleeEntityGoal<>(villagerEntity, WitchEntity.class, 6.0F, 1.0D, 1.2D));
-        }
-
-        if (entity instanceof VillagerEntity villagerEntity) {
-            if (GuardVillagersConfig.blackSmithHealing)
-                villagerEntity.goalSelector.add(1, new HealGolemGoal(villagerEntity));
-            if (GuardVillagersConfig.clericHealing)
-                villagerEntity.goalSelector.add(1, new HealGuardAndPlayerGoal(villagerEntity, 1.0D, 100, 0, 10.0F));
-        }
-
-        if (entity instanceof IronGolemEntity golem) {
-
-            RevengeGoal tolerateFriendlyFire = new RevengeGoal(golem, GuardEntity.class).setGroupRevenge();
-            golem.targetSelector.getGoals().stream().map(PrioritizedGoal::getGoal).filter(it -> it instanceof RevengeGoal).findFirst().ifPresent(angerGoal -> {
-                golem.targetSelector.remove(angerGoal);
-                golem.targetSelector.add(2, tolerateFriendlyFire);
-            });
-        }
-
-        if (entity instanceof ZombieEntity zombie) {
-            zombie.targetSelector.add(3, new ActiveTargetGoal<>(zombie, GuardEntity.class, false));
-        }
-
-        if (entity instanceof RavagerEntity ravager) {
-            ravager.targetSelector.add(2, new ActiveTargetGoal<>(ravager, GuardEntity.class, false));
-        }
-
-        if (entity instanceof WitchEntity witch) {
-            if (GuardVillagersConfig.witchesVillager) {
-                witch.targetSelector.add(3, new ActiveTargetGoal<>(witch, VillagerEntity.class, true));
-                witch.targetSelector.add(3, new ActiveTargetGoal<>(witch, IronGolemEntity.class, true));
-                witch.targetSelector.add(3, new ActiveTargetGoal<>(witch, GuardEntity.class, true));
-            }
-        }
-
-        if (entity instanceof CatEntity cat) {
-            cat.goalSelector.add(1, new FleeEntityGoal<>(cat, IllagerEntity.class, 12.0F, 1.0D, 1.2D));
-        }
-
-        return TriState.DEFAULT;
     }
 
     public static boolean hotvChecker(PlayerEntity player, GuardEntity guard) {

--- a/src/main/java/dev/sterner/guardvillagers/common/entity/GuardEntity.java
+++ b/src/main/java/dev/sterner/guardvillagers/common/entity/GuardEntity.java
@@ -7,9 +7,6 @@ import dev.sterner.guardvillagers.GuardVillagers;
 import dev.sterner.guardvillagers.GuardVillagersConfig;
 import dev.sterner.guardvillagers.common.screenhandler.GuardVillagerScreenHandler;
 import dev.sterner.guardvillagers.common.entity.goal.*;
-import io.github.fabricators_of_create.porting_lib.item.ShieldBlockItem;
-import io.github.fabricators_of_create.porting_lib.tool.ToolActions;
-import io.github.fabricators_of_create.porting_lib.util.LazyOptional;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.Enchantments;
@@ -102,7 +99,6 @@ public class GuardEntity extends PathAwareEntity implements CrossbowUser, Ranged
     protected boolean spawnWithArmor;
     private int remainingPersistentAngerTime;
     private UUID persistentAngerTarget;
-    private LazyOptional<?> itemHandler;
 
     public GuardEntity(EntityType<? extends GuardEntity> type, World world) {
         super(type, world);
@@ -475,12 +471,12 @@ public class GuardEntity extends PathAwareEntity implements CrossbowUser, Ranged
     @Override
     protected void takeShieldHit(LivingEntity entityIn) {
         super.takeShieldHit(entityIn);
-        if (entityIn.getMainHandStack().getItem() instanceof ShieldBlockItem) this.disableShield(true);
+        if (entityIn.getMainHandStack().getItem() instanceof AxeItem) this.disableShield(true);
     }
 
     @Override
     public void damageShield(float amount) {
-        if (this.activeItemStack.getItem().canPerformAction(this.activeItemStack, ToolActions.SHIELD_BLOCK)) {
+        if (this.activeItemStack.getItem() == Items.SHIELD) { // Might create compatibility problems with other mods that add shields
             if (amount >= 3.0F) {
                 int i = 1 + MathHelper.floor(amount);
                 Hand hand = this.getActiveHand();
@@ -502,7 +498,7 @@ public class GuardEntity extends PathAwareEntity implements CrossbowUser, Ranged
     public void setCurrentHand(Hand hand) {
         super.setCurrentHand(hand);
         ItemStack itemstack = this.getStackInHand(hand);
-        if (itemstack.canPerformAction(ToolActions.SHIELD_BLOCK)) {
+        if (itemstack.getItem() == Items.SHIELD) { // See above
 
             EntityAttributeInstance modifiableattributeinstance = this.getAttributeInstance(EntityAttributes.GENERIC_MOVEMENT_SPEED);
             modifiableattributeinstance.removeModifier(USE_ITEM_SPEED_PENALTY);

--- a/src/main/java/dev/sterner/guardvillagers/common/entity/goal/FollowShieldGuards.java
+++ b/src/main/java/dev/sterner/guardvillagers/common/entity/goal/FollowShieldGuards.java
@@ -1,10 +1,10 @@
 package dev.sterner.guardvillagers.common.entity.goal;
 
 import dev.sterner.guardvillagers.common.entity.GuardEntity;
-import io.github.fabricators_of_create.porting_lib.tool.ToolActions;
 import net.minecraft.entity.ai.NoPenaltyTargeting;
 import net.minecraft.entity.ai.TargetPredicate;
 import net.minecraft.entity.ai.goal.Goal;
+import net.minecraft.item.Items;
 import net.minecraft.util.math.Vec3d;
 import org.jetbrains.annotations.Nullable;
 
@@ -27,7 +27,7 @@ public class FollowShieldGuards extends Goal {
         List<? extends GuardEntity> list = this.taskOwner.getWorld().getNonSpectatingEntities(this.taskOwner.getClass(), this.taskOwner.getBoundingBox().expand(8.0D, 8.0D, 8.0D));
         if (!list.isEmpty()) {
             for (GuardEntity guard : list) {
-                if (!guard.isInvisible() && guard.getOffHandStack().canPerformAction(ToolActions.SHIELD_BLOCK) && guard.isBlocking()
+                if (!guard.isInvisible() && guard.getOffHandStack().getItem() == Items.SHIELD && guard.isBlocking() // Might create compatibility problems
                         && this.taskOwner.getWorld().getTargets(GuardEntity.class, NEARBY_GUARDS.setBaseMaxDistance(3.0D), guard,
                                 this.taskOwner.getBoundingBox().expand(5.0D))
                         .size() < 5) {

--- a/src/main/java/dev/sterner/guardvillagers/common/entity/goal/RaiseShieldGoal.java
+++ b/src/main/java/dev/sterner/guardvillagers/common/entity/goal/RaiseShieldGoal.java
@@ -2,7 +2,6 @@ package dev.sterner.guardvillagers.common.entity.goal;
 
 import dev.sterner.guardvillagers.GuardVillagersConfig;
 import dev.sterner.guardvillagers.common.entity.GuardEntity;
-import io.github.fabricators_of_create.porting_lib.tool.ToolActions;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.RangedAttackMob;
 import net.minecraft.entity.ai.goal.Goal;
@@ -10,6 +9,7 @@ import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.entity.mob.RavagerEntity;
 import net.minecraft.item.BowItem;
 import net.minecraft.item.CrossbowItem;
+import net.minecraft.item.Items;
 import net.minecraft.util.Hand;
 
 public class RaiseShieldGoal extends Goal {
@@ -22,8 +22,7 @@ public class RaiseShieldGoal extends Goal {
 
     @Override
     public boolean canStart() {
-        return !CrossbowItem.isCharged(guard.getMainHandStack()) && (guard.getOffHandStack().getItem().canPerformAction(guard.getOffHandStack(),
-                ToolActions.SHIELD_BLOCK) && raiseShield() && guard.shieldCoolDown == 0);
+        return !CrossbowItem.isCharged(guard.getMainHandStack()) && (guard.getOffHandStack().getItem() == Items.SHIELD && raiseShield() && guard.shieldCoolDown == 0);
     }
 
     @Override
@@ -33,7 +32,7 @@ public class RaiseShieldGoal extends Goal {
 
     @Override
     public void start() {
-        if (guard.getOffHandStack().getItem().canPerformAction(guard.getOffHandStack(), ToolActions.SHIELD_BLOCK))
+        if (guard.getOffHandStack().getItem() == Items.SHIELD)
             guard.setCurrentHand(Hand.OFF_HAND);
     }
 

--- a/src/main/java/dev/sterner/guardvillagers/mixin/MobEntityMixin.java
+++ b/src/main/java/dev/sterner/guardvillagers/mixin/MobEntityMixin.java
@@ -1,0 +1,45 @@
+package dev.sterner.guardvillagers.mixin;
+
+import dev.sterner.guardvillagers.GuardVillagersConfig;
+import dev.sterner.guardvillagers.common.entity.GuardEntity;
+import io.github.fabricators_of_create.porting_lib.entity.events.living.LivingEntityEvents;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.Targeter;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.passive.IronGolemEntity;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(MobEntity.class)
+public abstract class MobEntityMixin extends LivingEntity implements Targeter {
+    protected MobEntityMixin(EntityType<? extends LivingEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
+    @Inject(method = "setTarget", at = @At("TAIL"))
+    private void onSetTarget(@Nullable LivingEntity target, CallbackInfo ci) {
+        if (target == null || ((MobEntity)(Object)this) instanceof GuardEntity) {
+            return;
+        }
+        boolean isVillager = target.getType() == EntityType.VILLAGER || target instanceof GuardEntity;
+        if (isVillager) {
+            List<MobEntity> list = ((MobEntity)(Object)this).getWorld().getNonSpectatingEntities(MobEntity.class, ((MobEntity)(Object)this).getBoundingBox().expand(GuardVillagersConfig.guardVillagerHelpRange, 5.0D, GuardVillagersConfig.guardVillagerHelpRange));
+            for (MobEntity mobEntity : list) {
+                if ((mobEntity instanceof GuardEntity || ((MobEntity)(Object)this).getType() == EntityType.IRON_GOLEM) && mobEntity.getTarget() == null) {
+                    mobEntity.setTarget(((MobEntity)(Object)this));
+                }
+            }
+        }
+
+        if (((MobEntity)(Object)this) instanceof IronGolemEntity golem && target instanceof GuardEntity) {
+            golem.setTarget(null);
+        }
+    }
+}

--- a/src/main/java/dev/sterner/guardvillagers/mixin/MobEntityMixin.java
+++ b/src/main/java/dev/sterner/guardvillagers/mixin/MobEntityMixin.java
@@ -2,7 +2,6 @@ package dev.sterner.guardvillagers.mixin;
 
 import dev.sterner.guardvillagers.GuardVillagersConfig;
 import dev.sterner.guardvillagers.common.entity.GuardEntity;
-import io.github.fabricators_of_create.porting_lib.entity.events.living.LivingEntityEvents;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.Targeter;

--- a/src/main/java/dev/sterner/guardvillagers/mixin/ServerWorldMixin.java
+++ b/src/main/java/dev/sterner/guardvillagers/mixin/ServerWorldMixin.java
@@ -1,0 +1,110 @@
+package dev.sterner.guardvillagers.mixin;
+
+import dev.sterner.guardvillagers.GuardVillagersConfig;
+import dev.sterner.guardvillagers.common.entity.GuardEntity;
+import dev.sterner.guardvillagers.common.entity.goal.AttackEntityDaytimeGoal;
+import dev.sterner.guardvillagers.common.entity.goal.HealGolemGoal;
+import dev.sterner.guardvillagers.common.entity.goal.HealGuardAndPlayerGoal;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.ai.goal.ActiveTargetGoal;
+import net.minecraft.entity.ai.goal.FleeEntityGoal;
+import net.minecraft.entity.ai.goal.PrioritizedGoal;
+import net.minecraft.entity.ai.goal.RevengeGoal;
+import net.minecraft.entity.mob.*;
+import net.minecraft.entity.passive.*;
+import net.minecraft.entity.raid.RaiderEntity;
+import net.minecraft.registry.DynamicRegistryManager;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.profiler.Profiler;
+import net.minecraft.world.MutableWorldProperties;
+import net.minecraft.world.StructureWorldAccess;
+import net.minecraft.world.World;
+import net.minecraft.world.dimension.DimensionType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.function.Supplier;
+
+@Mixin(ServerWorld.class)
+public abstract class ServerWorldMixin extends World implements StructureWorldAccess {
+
+    protected ServerWorldMixin(MutableWorldProperties properties, RegistryKey<World> registryRef, DynamicRegistryManager registryManager, RegistryEntry<DimensionType> dimensionEntry, Supplier<Profiler> profiler, boolean isClient, boolean debugWorld, long biomeAccess, int maxChainedNeighborUpdates) {
+        super(properties, registryRef, registryManager, dimensionEntry, profiler, isClient, debugWorld, biomeAccess, maxChainedNeighborUpdates);
+    }
+
+    @Inject(method = "spawnEntity", at = @At("TAIL"))
+    private void onSpawn(Entity entity, CallbackInfoReturnable<Boolean> cir) {
+        if (GuardVillagersConfig.raidAnimals) {
+            if (entity instanceof RaiderEntity raiderEntity)
+                if (raiderEntity.hasActiveRaid()) {
+                    raiderEntity.targetSelector.add(5, new ActiveTargetGoal<>(raiderEntity, AnimalEntity.class, false));
+                }
+        }
+
+        if (GuardVillagersConfig.attackAllMobs) {
+            if (entity instanceof HostileEntity && !(entity instanceof SpiderEntity)) {
+                MobEntity mob = (MobEntity) entity;
+                mob.targetSelector.add(2, new ActiveTargetGoal<>(mob, GuardEntity.class, false));
+            }
+            if (entity instanceof SpiderEntity spider) {
+                spider.targetSelector.add(3, new AttackEntityDaytimeGoal<>(spider, GuardEntity.class));
+            }
+        }
+
+
+        if (entity instanceof IllagerEntity illager) {
+            if (GuardVillagersConfig.illagersRunFromPolarBears) {
+                illager.goalSelector.add(2, new FleeEntityGoal<>(illager, PolarBearEntity.class, 6.0F, 1.0D, 1.2D));
+            }
+
+            illager.targetSelector.add(2, new ActiveTargetGoal<>(illager, GuardEntity.class, false));
+        }
+
+        if (entity instanceof VillagerEntity villagerEntity) {
+            if (GuardVillagersConfig.villagersRunFromPolarBears)
+                villagerEntity.goalSelector.add(2, new FleeEntityGoal<>(villagerEntity, PolarBearEntity.class, 6.0F, 1.0D, 1.2D));
+            if (GuardVillagersConfig.witchesVillager)
+                villagerEntity.goalSelector.add(2, new FleeEntityGoal<>(villagerEntity, WitchEntity.class, 6.0F, 1.0D, 1.2D));
+        }
+
+        if (entity instanceof VillagerEntity villagerEntity) {
+            if (GuardVillagersConfig.blackSmithHealing)
+                villagerEntity.goalSelector.add(1, new HealGolemGoal(villagerEntity));
+            if (GuardVillagersConfig.clericHealing)
+                villagerEntity.goalSelector.add(1, new HealGuardAndPlayerGoal(villagerEntity, 1.0D, 100, 0, 10.0F));
+        }
+
+        if (entity instanceof IronGolemEntity golem) {
+
+            RevengeGoal tolerateFriendlyFire = new RevengeGoal(golem, GuardEntity.class).setGroupRevenge();
+            golem.targetSelector.getGoals().stream().map(PrioritizedGoal::getGoal).filter(it -> it instanceof RevengeGoal).findFirst().ifPresent(angerGoal -> {
+                golem.targetSelector.remove(angerGoal);
+                golem.targetSelector.add(2, tolerateFriendlyFire);
+            });
+        }
+
+        if (entity instanceof ZombieEntity zombie) {
+            zombie.targetSelector.add(3, new ActiveTargetGoal<>(zombie, GuardEntity.class, false));
+        }
+
+        if (entity instanceof RavagerEntity ravager) {
+            ravager.targetSelector.add(2, new ActiveTargetGoal<>(ravager, GuardEntity.class, false));
+        }
+
+        if (entity instanceof WitchEntity witch) {
+            if (GuardVillagersConfig.witchesVillager) {
+                witch.targetSelector.add(3, new ActiveTargetGoal<>(witch, VillagerEntity.class, true));
+                witch.targetSelector.add(3, new ActiveTargetGoal<>(witch, IronGolemEntity.class, true));
+                witch.targetSelector.add(3, new ActiveTargetGoal<>(witch, GuardEntity.class, true));
+            }
+        }
+
+        if (entity instanceof CatEntity cat) {
+            cat.goalSelector.add(1, new FleeEntityGoal<>(cat, IllagerEntity.class, 12.0F, 1.0D, 1.2D));
+        }
+    }
+}

--- a/src/main/java/dev/sterner/guardvillagers/mixin/ServerWorldMixin.java
+++ b/src/main/java/dev/sterner/guardvillagers/mixin/ServerWorldMixin.java
@@ -55,7 +55,6 @@ public abstract class ServerWorldMixin extends World implements StructureWorldAc
             }
         }
 
-
         if (entity instanceof IllagerEntity illager) {
             if (GuardVillagersConfig.illagersRunFromPolarBears) {
                 illager.goalSelector.add(2, new FleeEntityGoal<>(illager, PolarBearEntity.class, 6.0F, 1.0D, 1.2D));
@@ -69,9 +68,7 @@ public abstract class ServerWorldMixin extends World implements StructureWorldAc
                 villagerEntity.goalSelector.add(2, new FleeEntityGoal<>(villagerEntity, PolarBearEntity.class, 6.0F, 1.0D, 1.2D));
             if (GuardVillagersConfig.witchesVillager)
                 villagerEntity.goalSelector.add(2, new FleeEntityGoal<>(villagerEntity, WitchEntity.class, 6.0F, 1.0D, 1.2D));
-        }
 
-        if (entity instanceof VillagerEntity villagerEntity) {
             if (GuardVillagersConfig.blackSmithHealing)
                 villagerEntity.goalSelector.add(1, new HealGolemGoal(villagerEntity));
             if (GuardVillagersConfig.clericHealing)
@@ -79,7 +76,6 @@ public abstract class ServerWorldMixin extends World implements StructureWorldAc
         }
 
         if (entity instanceof IronGolemEntity golem) {
-
             RevengeGoal tolerateFriendlyFire = new RevengeGoal(golem, GuardEntity.class).setGroupRevenge();
             golem.targetSelector.getGoals().stream().map(PrioritizedGoal::getGoal).filter(it -> it instanceof RevengeGoal).findFirst().ifPresent(angerGoal -> {
                 golem.targetSelector.remove(angerGoal);

--- a/src/main/resources/guardvillagers.mixins.json
+++ b/src/main/resources/guardvillagers.mixins.json
@@ -3,7 +3,8 @@
   "package": "dev.sterner.guardvillagers.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "VillagerTaskListProviderMixin"
+    "VillagerTaskListProviderMixin",
+    "ServerWorldMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/guardvillagers.mixins.json
+++ b/src/main/resources/guardvillagers.mixins.json
@@ -3,8 +3,9 @@
   "package": "dev.sterner.guardvillagers.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "VillagerTaskListProviderMixin",
-    "ServerWorldMixin"
+    "MobEntityMixin",
+    "ServerWorldMixin",
+    "VillagerTaskListProviderMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
The usage of PortingLib is unnecessary and can be removed, also fixes bug where guards don’t use their shield.

This should also help in updating the mod faster, since PortingLib is slow to update right now.